### PR TITLE
Disable text-decoration for --hover nav items

### DIFF
--- a/scss/pack/seed-nav/components/modifiers/_hover.scss
+++ b/scss/pack/seed-nav/components/modifiers/_hover.scss
@@ -10,6 +10,7 @@
     .#{$seed-nav-link-namespace} {
       &:hover {
         background-color: $seed-nav-link-hover-background-color;
+        text-decoration: none;
       }
     }
   }

--- a/test/nav-hover.js
+++ b/test/nav-hover.js
@@ -16,4 +16,10 @@ describe('seed-nav: nav-hover modifier', function() {
 
     assert.isOk($o.exists());
   });
+
+  it('should have no text-decoration', function() {
+    var $o = output.$('.c-nav--hover .c-nav__link:hover');
+
+    assert.equal($o.getProp('text-decoration'), 'none');
+  });
 });


### PR DESCRIPTION
This fixes a conflict with seed-link, which adds text-decoration underline to all `a` elements.

:heart: :heart: :heart: