### PR TITLE
Make the tab modifier response

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+example/
+node_modules/
+test/
+
+*.log

--- a/package.json
+++ b/package.json
@@ -42,14 +42,14 @@
     "node": ">=4"
   },
   "devDependencies": {
-    "mkdirp": "^0.5.1",
-    "node-sass": "^3.10.0",
-    "seed-bistro": "0.0.3"
+    "mkdirp": "0.5.1",
+    "node-sass": "4.5.3",
+    "seed-bistro": "0.1.9"
   },
   "dependencies": {
     "sass-pathfinder": "0.0.5",
     "seed-border": "0.0.10",
-    "seed-breakpoints": "0.4.0",
-    "seed-publish": "0.1.1"
+    "seed-breakpoints": "0.4.1",
+    "seed-publish": "0.2.0"
   }
 }

--- a/scss/pack/seed-nav/components/__index.scss
+++ b/scss/pack/seed-nav/components/__index.scss
@@ -3,4 +3,3 @@
 @import "./nav";
 @import "./nav-item";
 @import "./nav-link";
-

--- a/scss/pack/seed-nav/components/modifiers/_tabs.scss
+++ b/scss/pack/seed-nav/components/modifiers/_tabs.scss
@@ -1,27 +1,30 @@
 // Modifiers :: Tabs
 
 // Dependencies
+@import "pack/seed-breakpoints/config";
 @import "pack/seed-border/config";
 @import "pack/seed-publish/_index";
 @import "../../config";
 
 @include export(seed-nav) {
   .#{$seed-nav-tabs-namespace} {
-    border-bottom: $seed-border;
+    @include breakpoint-all() {
+      border-bottom: $seed-border;
 
-    .#{$seed-nav-link-namespace} {
-      border-bottom-color: transparent;
-      border-bottom-style: solid;
-      border-bottom-width: $seed-nav-tabs-link-border-width;
-      color: $seed-nav-tabs-link-color;
-    }
+      .#{$seed-nav-link-namespace} {
+        border-bottom-color: transparent;
+        border-bottom-style: solid;
+        border-bottom-width: $seed-nav-tabs-link-border-width;
+        color: $seed-nav-tabs-link-color;
+      }
 
-    // States: Active
-    .#{$seed-nav-item-namespace}.#{$seed-nav-link-active-namespace} > #{$seed-nav-link-namespace},
-    .#{$seed-nav-link-namespace}.#{$seed-nav-link-active-namespace} {
-      border-bottom-color: $seed-nav-tabs-link-active-border-color;
-      color: $seed-nav-tabs-link-active-color;
-      font-weight: $seed-nav-tabs-link-active-font-weight;
+      // States: Active
+      .#{$seed-nav-item-namespace}.#{$seed-nav-link-active-namespace} > #{$seed-nav-link-namespace},
+      .#{$seed-nav-link-namespace}.#{$seed-nav-link-active-namespace} {
+        border-bottom-color: $seed-nav-tabs-link-active-border-color;
+        color: $seed-nav-tabs-link-active-color;
+        font-weight: $seed-nav-tabs-link-active-font-weight;
+      }
     }
   }
 }

--- a/test/nav-tabs.js
+++ b/test/nav-tabs.js
@@ -4,12 +4,13 @@
 
 var assert = require('chai').assert;
 var barista = require('seed-barista');
+var expect = require('chai').expect;
 
 describe('seed-nav: nav-tabs modifier', function() {
   var style = `
     @import "./_index";
   `;
-  var output = barista({ content: style });
+  var output = barista({ content: style }).mount();
 
   it('should have a nav-tabs modifier', function() {
     var $o = output.$('.c-nav--tabs');
@@ -21,5 +22,31 @@ describe('seed-nav: nav-tabs modifier', function() {
     var $o = output.$('.c-nav--tabs');
 
     assert.isOk($o.getProp('border-bottom'));
+  });
+
+  it('should have responsive modifiers', () => {
+    expect(output.rule('.c-nav--tabs@sm').at(['min']).exists()).to.be.true;
+    expect(output.rule('.c-nav--tabs@md').at(['min']).exists()).to.be.true;
+    expect(output.rule('.c-nav--tabs@lg').at(['min']).exists()).to.be.true;
+
+    expect(output.rule('.c-nav--tabs@sm').at(['max'])).to.be.false;
+    expect(output.rule('.c-nav--tabs@md').at(['max'])).to.be.false;
+    expect(output.rule('.c-nav--tabs@lg').at(['max'])).to.be.false;
+  });
+
+  describe('link', () => {
+    it('should have correct inactive styles', () => {
+      const el = output.find('.c-nav--tabs .c-nav__link');
+
+      expect(el.prop('border-bottom-color')).to.equal('transparent');
+      expect(el.prop('font-weight')).to.not.equal('700');
+    });
+
+    it('should have correct active styles', () => {
+      const el = output.find('.c-nav--tabs .c-nav__link.is-active');
+
+      expect(el.prop('border-bottom-color')).to.not.equal('transparent');
+      expect(el.prop('font-weight')).to.equal('700');
+    });
   });
 });


### PR DESCRIPTION
* Wrap the CSS generating the tab modifier style with breakpoint-all
* Add tests for the tab responsive modifier
* Update dependencies

This should be minor bumped, due to the jump in dep versions